### PR TITLE
quick account edit bug fix

### DIFF
--- a/app/components/account/account-fields.tsx
+++ b/app/components/account/account-fields.tsx
@@ -58,7 +58,7 @@ export default function AccountFields({id, role}: {id: string, role: string}) {
             </p>
 			<p className="text-sm capitalize">
 				<span className="mr-12 font-semibold">Tags:</span>
-				{tags.length > 0 
+				{Array.isArray(tags) && tags.length > 0 // handles array that isn't defined or is empty
 					? tags
 						.map((tag) => {
 							const foundTag = predefinedTags.find((t) => t.value === tag);

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,12 @@ All the notable additions and fixes.
 
 This changelog follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+# [2.0.1] - 2025-01-06 # account edit bug fix
+
+### Fixed
+
+- Added type checking in a component, to prevent compile error when an account doesn't have tags.
+
 # [2.0.0] - 2024-12-29 # backward incompatible API changes
 
 ### Added 


### PR DESCRIPTION
-Before, an account without tags would not be able to access the account edit page (resulted in compile error)
-Now, the account field component handles the case of an undefined tags array.